### PR TITLE
compare current semver before updating dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "raptor-regexp": "^1.0.1",
     "raptor-util": "^1.0.10",
     "resolve-from": "^2.0.0",
+    "semver": "^5.1.0",
     "shelljs": "^0.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This prevents from downgrading dependencies

Prior to this, if a dependency was already defined higher than that required by Marko v3, it would be downgraded to the one defined in this code.

```
[modified] package.json
  - [info] Updated "lasso" version: ^2.1.5 → ^2.0.0 (in "dependencies")
```

With this, it now compares the semver of the current dependency and only upgrades if it's actually lower than what's required.
