### PR TITLE
Fixing empty assign declaration;

### DIFF
--- a/src/transformers/assign-tag.js
+++ b/src/transformers/assign-tag.js
@@ -7,7 +7,7 @@ function addAssign(fromEl, toEl) {
     fromEl.removeAttribute('var');
     fromEl.removeAttribute('value');
 
-    toEl.setAttributeValue(varAttr.value.value, valueAttr && valueAttr.value);
+    toEl.setAttributeValue(varAttr.value.value, (valueAttr && valueAttr.value) || "");
 }
 
 exports.transform = function(el) {


### PR DESCRIPTION
The original v2 template code looks like this:

```
<assign name="someVar" value=""/>
```

The `markoc` compiler apparently doesn't like the following conversion of the above v2 template:

```
<assign someVar/>
```

Therefore a better practice when there is no value to be passed through, so that the value comes out as an empty string, so that `markoc` will compile properly:

```
<assign somVar=""/>
```

Hopefully this change makes sense and is in line with the thinking of the assign tag.

(Also, this case should have a corresponding test, which I don't apparently see.)
